### PR TITLE
change Constants.java, refactor + swap out magic numbers

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -8,9 +8,6 @@ import frc.robot.util.ControlHandler.TriggerType;
  * This is different from the {@link frc.robot.Flags Flags} class, which toggles functionality on the robot and may be changed more often.
  */
 public final class Constants {
-    // this is an expert coding pattern that should absolutely be used.
-    public static final int SOME_MADE_UP_WRONG_PORT = 0xDEADBEEF;
-
     private Constants() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
@@ -49,96 +46,74 @@ public final class Constants {
         }
     }
 
-    /**
-     * Key: RIO = RoboRio, COD = CANCoder, DRI = Drive Motor, ROT = Rotation Motor, INT = Intake, CON = Conveyor, SHO = Shooter, CLI = Climber
-     * <pre>
-     * CAN IDs USED:
-     * 0  (RIO)
-     * 1  (COD)
-     * 2  (ROT)
-     * 3  (COD)
-     * 4  (DRI)
-     * 5  (ROT)
-     * 6  (COD)
-     * 7  (DRI)
-     * 8  (ROT)
-     * 9  (DRI)
-     * 10 (ROT)
-     * 11 (DRI)
-     * 12 (COD)
-     * 13 (INT)
-     * 14 (INT)
-     * 15 (CON)
-     * 16 (SHO)
-     * 17 (SHO)
-     * 18 (CON)
-     * 19 (CLI)
-     * 20 (CLI)
-     * 21 (SHO)
-     * 22 (CON)
-     * 23 (INT)
-     *
-     * </pre>
-     * <pre>
-     * DIOs USED:
-     * 0 (SHO)
-     * 1 (SHO)
-     * 2 (SHO)
-     * 3 (INT)
-     * 4 (INT)
-     * 5 (INT)
-     *
-     * </pre>
-     * <pre>
-     * PWMs USED:
-     * 0 (SHO)
-     * 1 (SHO)
-     */
     public static class PortConstants {
-        // CAN IDs
+        /**
+         * Key: RIO = RoboRio, COD = CANCoder, DRI = Drive Motor, ROT = Rotation Motor, ELE = Elevator, CLI = Climber
+         * <pre>
+         * CAN IDs USED:
+         * 0  (RIO)
+         *
+         * 1  (COD)
+         * 2  (ROT)
+         * 3  (COD)
+         * 4  (DRI)
+         * 5  (ROT)
+         * 6  (COD)
+         * 7  (DRI)
+         * 8  (ROT)
+         * 9  (DRI)
+         * 10 (ROT)
+         * 11 (DRI)
+         * 12 (COD)
+         *
+         * 17 (ELE)
+         *
+         * 21 (ELE)
+         */
+        public static class CAN {
+            // Drive Train (COD, DRI, ROT)
+            public static final int DTRAIN_FRONT_LEFT_DRIVE_MOTOR_ID = 9;
+            public static final int DTRAIN_FRONT_RIGHT_DRIVE_MOTOR_ID = 11;
+            public static final int DTRAIN_BACK_LEFT_DRIVE_MOTOR_ID = 7;
+            public static final int DTRAIN_BACK_RIGHT_DRIVE_MOTOR_ID = 4;
+            public static final int DTRAIN_FRONT_LEFT_ROTATION_MOTOR_ID = 8;
+            public static final int DTRAIN_FRONT_RIGHT_ROTATION_MOTOR_ID = 2;
+            public static final int DTRAIN_BACK_LEFT_ROTATION_MOTOR_ID = 5;
+            public static final int DTRAIN_BACK_RIGHT_ROTATION_MOTOR_ID = 10;
+            public static final int DTRAIN_FRONT_LEFT_CANCODER_ID = 12;
+            public static final int DTRAIN_FRONT_RIGHT_CANCODER_ID = 3;
+            public static final int DTRAIN_BACK_LEFT_CANCODER_ID = 6;
+            public static final int DTRAIN_BACK_RIGHT_CANCODER_ID = 1;
 
-        // (2025) Telescoping Arm
-        public static final int RIGHT_ELEVATOR_MOTOR_ID = 17;
-        public static final int RIGHT_CLIMB_ABS_ENCODER_ID = 1;
+            // (2025) Elevators (ELE)
+            public static final int RIGHT_ELEVATOR_MOTOR_ID = 17;
+            public static final int LEFT_ELEVATOR_MOTOR_ID = 21;
+        }
 
-        public static final int LEFT_ELEVATOR_MOTOR_ID = 21;
-        public static final int LEFT_CLIMB_ABS_ENCODER_ID = 0;
+        public static class PWM {
 
+        }
 
-        // Drive Train (COD, DRI, ROT)
-        public static final int DTRAIN_FRONT_LEFT_DRIVE_MOTOR_ID = 9;
-        public static final int DTRAIN_FRONT_RIGHT_DRIVE_MOTOR_ID = 11;
-        public static final int DTRAIN_BACK_LEFT_DRIVE_MOTOR_ID = 7;
-        public static final int DTRAIN_BACK_RIGHT_DRIVE_MOTOR_ID = 4;
+        /**
+         * ELE = Elevator, CLI = Climber
+         * <pre>
+         * DIOs USED:
+         * 0 (ELE)
+         * 1 (ELE)
+         * 2 (ELE)
+         * 3 (ELE)
+         * 4 (ELE)
+         * 5 (ELE)
+         */
+        public static class DIO {
+            public static final int RIGHT_CLIMB_ABS_ENCODER_ABS_PORT = 1;
+            public static final int RIGHT_CLIMB_ABS_ENCODER_A_PORT = 5;
+            public static final int RIGHT_CLIMB_ABS_ENCODER_B_PORT = 4;
 
-        public static final int DTRAIN_FRONT_LEFT_ROTATION_MOTOR_ID = 8;
-        public static final int DTRAIN_FRONT_RIGHT_ROTATION_MOTOR_ID = 2;
-        public static final int DTRAIN_BACK_LEFT_ROTATION_MOTOR_ID = 5;
-        public static final int DTRAIN_BACK_RIGHT_ROTATION_MOTOR_ID = 10;
-
-        public static final int DTRAIN_FRONT_LEFT_CANCODER_ID = 12;
-        public static final int DTRAIN_FRONT_RIGHT_CANCODER_ID = 3;
-        public static final int DTRAIN_BACK_LEFT_CANCODER_ID = 6;
-        public static final int DTRAIN_BACK_RIGHT_CANCODER_ID = 1;
-
-        // DIO Ports
-
-        // Intake (INT)
-        public static final int INTAKE_ABSOLUTE_ENCODER_ABS_PORT = 3;
-        public static final int INTAKE_ABSOLUTE_ENCODER_A_PORT = 4;
-        public static final int INTAKE_ABSOLUTE_ENCODER_B_PORT = 5;
-
-        // Shooter (SHO)
-        public static final int SHOOTER_ABSOLUTE_ENCODER_ABS_PORT = 0;
-        public static final int SHOOTER_ABSOLUTE_ENCODER_A_PORT = 1;
-        public static final int SHOOTER_ABSOLUTE_ENCODER_B_PORT = 2;
-
-
-        // PWM Ports
-
-        // Sho)
-        public static final int SHOOTER_LEFT_SERVO_PORT = 1;
-        public static final int SHOOTER_RIGHT_SERVO_PORT = 0;
+            public static final int LEFT_CLIMB_ABS_ENCODER_ABS_PORT = 0;
+            public static final int LEFT_CLIMB_ABS_ENCODER_A_PORT = 2;
+            public static final int LEFT_CLIMB_ABS_ENCODER_B_PORT = 3;
+        }
     }
 
     public static class DriveConstants {

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -15,7 +15,6 @@ import edu.wpi.first.networktables.GenericPublisher;
 import edu.wpi.first.networktables.NetworkTableType;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
-import frc.robot.Robot;
 import frc.robot.util.NetworkTablesUtil;
 import frc.robot.util.ThroughboreEncoder;
 
@@ -50,13 +49,13 @@ public class ElevatorSubsystem extends SubsystemBase {
     public static final GenericPublisher rightHeightAbsRotPub = NetworkTablesUtil.getPublisher("robot", "rightElevAR", NetworkTableType.kDouble);
 
     public ElevatorSubsystem() {
-        rightMotor = new SparkMax(Constants.PortConstants.RIGHT_ELEVATOR_MOTOR_ID, MotorType.kBrushless);
-        leftMotor = new SparkMax(Constants.PortConstants.LEFT_ELEVATOR_MOTOR_ID, MotorType.kBrushless);
+        rightMotor = new SparkMax(Constants.PortConstants.CAN.RIGHT_ELEVATOR_MOTOR_ID, MotorType.kBrushless);
+        leftMotor = new SparkMax(Constants.PortConstants.CAN.LEFT_ELEVATOR_MOTOR_ID, MotorType.kBrushless);
         rightMotorEncoder = rightMotor.getEncoder();
         leftMotorEncoder = leftMotor.getEncoder();
 
-        rightThroughboreEncoder = new ThroughboreEncoder(Constants.PortConstants.RIGHT_CLIMB_ABS_ENCODER_ID, 5, 4, Rotation2d.fromDegrees(9.40).getRotations(), false, true, true); // 742.5 deg = 50 cm up
-        leftThroughboreEncoder = new ThroughboreEncoder(Constants.PortConstants.LEFT_CLIMB_ABS_ENCODER_ID, 2, 3, -Rotation2d.fromDegrees(124.5).getRotations(), true, false, true); // 742.5 deg = 50 cm up
+        rightThroughboreEncoder = new ThroughboreEncoder(Constants.PortConstants.DIO.RIGHT_CLIMB_ABS_ENCODER_ABS_PORT, 5, 4, Rotation2d.fromDegrees(9.40).getRotations(), false, true, true); // 742.5 deg = 50 cm up
+        leftThroughboreEncoder = new ThroughboreEncoder(Constants.PortConstants.DIO.LEFT_CLIMB_ABS_ENCODER_ABS_PORT, 2, 3, -Rotation2d.fromDegrees(124.5).getRotations(), true, false, true); // 742.5 deg = 50 cm up
 
         this.rightPIDController = this.rightMotor.getClosedLoopController();
         this.leftPIDController = this.leftMotor.getClosedLoopController();

--- a/src/main/java/frc/robot/subsystems/swerve/DriveTrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/DriveTrainSubsystem.java
@@ -37,7 +37,6 @@ import frc.robot.commands.ManualDriveCommand;
 import frc.robot.subsystems.staticsubsystems.RobotGyro;
 import frc.robot.util.NetworkTablesUtil;
 import frc.robot.util.QuestNav;
-import frc.robot.util.Util;
 
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 
@@ -59,33 +58,33 @@ public class DriveTrainSubsystem extends SubsystemBase {
     public static final Translation2d cameraLocation = backRightLocation.plus(new Translation2d(0.075, 0.205));
     static SwerveModuleState[] optimizedTargetStates = new SwerveModuleState[4]; // for debugging purposes
     private final SwerveModule frontLeft = new SwerveModule(
-            PortConstants.DTRAIN_FRONT_LEFT_DRIVE_MOTOR_ID,
-            PortConstants.DTRAIN_FRONT_LEFT_ROTATION_MOTOR_ID,
-            PortConstants.DTRAIN_FRONT_LEFT_CANCODER_ID,
+            PortConstants.CAN.DTRAIN_FRONT_LEFT_DRIVE_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_FRONT_LEFT_ROTATION_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_FRONT_LEFT_CANCODER_ID,
             "fL_12",
             INVERT_DRIVE_MOTORS,
             true
     );
     private final SwerveModule frontRight = new SwerveModule(
-            PortConstants.DTRAIN_FRONT_RIGHT_DRIVE_MOTOR_ID,
-            PortConstants.DTRAIN_FRONT_RIGHT_ROTATION_MOTOR_ID,
-            PortConstants.DTRAIN_FRONT_RIGHT_CANCODER_ID,
+            PortConstants.CAN.DTRAIN_FRONT_RIGHT_DRIVE_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_FRONT_RIGHT_ROTATION_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_FRONT_RIGHT_CANCODER_ID,
             "fR_03",
             INVERT_DRIVE_MOTORS,
             true
     );
     private final SwerveModule backLeft = new SwerveModule(
-            PortConstants.DTRAIN_BACK_LEFT_DRIVE_MOTOR_ID,
-            PortConstants.DTRAIN_BACK_LEFT_ROTATION_MOTOR_ID,
-            PortConstants.DTRAIN_BACK_LEFT_CANCODER_ID,
+            PortConstants.CAN.DTRAIN_BACK_LEFT_DRIVE_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_BACK_LEFT_ROTATION_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_BACK_LEFT_CANCODER_ID,
             "bL_06",
             INVERT_DRIVE_MOTORS,
             true
     );
     private final SwerveModule backRight = new SwerveModule(
-            PortConstants.DTRAIN_BACK_RIGHT_DRIVE_MOTOR_ID,
-            PortConstants.DTRAIN_BACK_RIGHT_ROTATION_MOTOR_ID,
-            PortConstants.DTRAIN_BACK_RIGHT_CANCODER_ID,
+            PortConstants.CAN.DTRAIN_BACK_RIGHT_DRIVE_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_BACK_RIGHT_ROTATION_MOTOR_ID,
+            PortConstants.CAN.DTRAIN_BACK_RIGHT_CANCODER_ID,
             "bR_01",
             INVERT_DRIVE_MOTORS,
             true


### PR DESCRIPTION
1. Moves the A/B ports for the elevator absolute encoders into `Constants.java`
2. Separates CAN, DIO, PWM port numbers into subclasses of `PortConstants`
3. Delete old port numbers from last year
4. Delete `0xDEADBEEF` constant that we shouldn't be using anyways